### PR TITLE
Fontawesome update fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module.exports = {
     loaders: [
       // the url-loader uses DataUrls.
       // the file-loader emits files.
-      { test: /\.woff(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&minetype=application/font-woff" },
+      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&minetype=application/font-woff" },
       { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "file-loader" }
     ]
   }

--- a/font-awesome-styles.loader.js
+++ b/font-awesome-styles.loader.js
@@ -3,14 +3,13 @@ var styles = [
 
     'bordered-pulled',
     'core',
-    'extras',
     'fixed-width',
     'icons',
     'larger',
     'list',
     'path',
     'rotated-flipped',
-    'spinning',
+    'animated',
     'stacked'
 ];
 

--- a/font-awesome.config.js
+++ b/font-awesome.config.js
@@ -3,14 +3,13 @@ module.exports = {
         'mixins': true,
         'bordered-pulled': true,
         'core': true,
-        'extras': true,
         'fixed-width': true,
         'icons': true,
         'larger': true,
         'list': true,
         'path': true,
         'rotated-flipped': true,
-        'spinning': true,
+        'animated': true,
         'stacked': true
     }
 };


### PR DESCRIPTION
Fontawesome changed a few things that broke this package.  They removed their `spinning` class and there was a `.woff2` file that was also being ignored by the loader.  This fixed it for me.
