### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "url": "https://github.com/gowravshekar/font-awesome-webpack/issues"
     },
     "dependencies": {
-        "css-loader": "~0.17.0",
-        "less-loader": "~2.2.0",
-        "style-loader": "~0.12.3"
+        "css-loader": "~0.26.1",
+        "less-loader": "~2.2.3",
+        "style-loader": "~0.13.1"
     },
     "peerDependencies": {
         "font-awesome": ">=4.3.0"


### PR DESCRIPTION
The old version of css-loader required an old verision of cssnano (2.x) which [contains SyntaxErrors](https://github.com/ben-eb/cssnano/blob/v2.6.1/bin/cmd.js#L17), making it impossible to use it with Babel.