### PR TITLE
upgraded deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "url": "https://github.com/gowravshekar/font-awesome-webpack/issues"
     },
     "dependencies": {
-        "css-loader": "~0.26.1",
-        "less-loader": "~2.2.3",
-        "style-loader": "~0.13.1"
+        "css-loader": "~0.28.11",
+        "less-loader": "~4.1.0",
+        "style-loader": "~0.20.3"
     },
     "peerDependencies": {
         "font-awesome": ">=4.3.0"


### PR DESCRIPTION
This patch worked for me to be able to use FA with webpack 4. However, I did not test for other webpack versions, But I think it's ok.